### PR TITLE
Fix resolve test when there are multiple addresses on the loopback interface.

### DIFF
--- a/Tests/LowSocketsTests/AddressTests.swift
+++ b/Tests/LowSocketsTests/AddressTests.swift
@@ -150,7 +150,7 @@ class AddressTests: XCTestCase {
           }
         }))
         let wantSet = Set<IPAddress>(c.value)
-        if !wantSet.isSubset(of: wantSet) {
+        if !wantSet.isSubset(of: gotSet) {
           XCTFail("want \(wantSet), got \(gotSet)")
         }
       } catch {

--- a/Tests/LowSocketsTests/AddressTests.swift
+++ b/Tests/LowSocketsTests/AddressTests.swift
@@ -150,7 +150,7 @@ class AddressTests: XCTestCase {
           }
         }))
         let wantSet = Set<IPAddress>(c.value)
-        if gotSet != wantSet {
+        if !wantSet.isSubset(of: wantSet) {
           XCTFail("want \(wantSet), got \(gotSet)")
         }
       } catch {


### PR DESCRIPTION
In the case of macOS 10.12.6, there are two IPv6 addresses on the loopback:
inet6 ::1 prefixlen 128 
inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1
The current logic fails because is compares with equal.